### PR TITLE
Improve test accuracy

### DIFF
--- a/CommonChickenRuntimeEngine/src/ccre/channel/DerivedFloatInput.java
+++ b/CommonChickenRuntimeEngine/src/ccre/channel/DerivedFloatInput.java
@@ -49,7 +49,7 @@ public abstract class DerivedFloatInput extends AbstractUpdatingInput implements
     public DerivedFloatInput(UpdatingInput... updates) {
         DerivedUpdate.onUpdates(updates, () -> {
             float newvalue = apply();
-            if (newvalue != value) {
+            if (Float.floatToIntBits(newvalue) != Float.floatToIntBits(value)) {
                 value = newvalue;
                 super.perform();
             }

--- a/CommonChickenRuntimeEngine/tests/ccre/channel/DerivedBooleanInputTest.java
+++ b/CommonChickenRuntimeEngine/tests/ccre/channel/DerivedBooleanInputTest.java
@@ -90,22 +90,27 @@ public class DerivedBooleanInputTest {
 
     @Test
     public void testApplyChange() {
-        BooleanCell v = new BooleanCell();
-        BooleanInput bi = new DerivedBooleanInput(es) {
-            @Override
-            protected boolean apply() {
-                return v.get();
-            }
-        };
-        bi.send(cbo);
-        boolean last = v.get();
-        for (boolean b : Values.interestingBooleans) {
-            v.set(b);
-            cbo.ifExpected = (b != last);
-            cbo.valueExpected = b;
-            es.event();
+        for (boolean initial : new boolean[] { false, true }) {
+            BooleanCell v = new BooleanCell(initial);
+            BooleanInput bi = new DerivedBooleanInput(es) {
+                @Override
+                protected boolean apply() {
+                    return v.get();
+                }
+            };
+            cbo.ifExpected = true;
+            cbo.valueExpected = initial;
+            bi.send(cbo);
             cbo.check();
-            last = b;
+            boolean last = v.get();
+            for (boolean b : Values.interestingBooleans) {
+                v.set(b);
+                cbo.ifExpected = (b != last);
+                cbo.valueExpected = b;
+                es.event();
+                cbo.check();
+                last = b;
+            }
         }
     }
 }

--- a/CommonChickenRuntimeEngine/tests/ccre/channel/DerivedFloatInputTest.java
+++ b/CommonChickenRuntimeEngine/tests/ccre/channel/DerivedFloatInputTest.java
@@ -24,6 +24,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import ccre.log.Logger;
 import ccre.testing.CountingEventOutput;
 import ccre.testing.CountingFloatOutput;
 import ccre.util.Values;
@@ -90,22 +91,30 @@ public class DerivedFloatInputTest {
 
     @Test
     public void testApplyChange() {
-        FloatCell v = new FloatCell();
-        FloatInput bi = new DerivedFloatInput(es) {
-            @Override
-            protected float apply() {
-                return v.get();
-            }
-        };
-        bi.send(cfo);
-        float last = v.get();
-        for (float f : Values.interestingFloats) {
-            v.set(f);
-            cfo.ifExpected = Float.floatToIntBits(f) != Float.floatToIntBits(last);
-            cfo.valueExpected = f;
-            es.event();
+        for (float initial : Values.interestingFloats) {
+            FloatCell v = new FloatCell(initial);
+            FloatInput bi = new DerivedFloatInput(es) {
+                @Override
+                protected float apply() {
+                    return v.get();
+                }
+            };
+            cfo.ifExpected = true;
+            cfo.valueExpected = initial;
+            bi.send(cfo);
             cfo.check();
-            last = f;
+            float last = v.get();
+            for (float f : Values.interestingFloats) {
+                v.set(f);
+                cfo.ifExpected = Float.floatToIntBits(f) != Float.floatToIntBits(last);
+                cfo.valueExpected = f;
+                if (f == 0.0 && f == 0.0) {
+                    Logger.fine("For: " + f + " / " + last);
+                }
+                es.event();
+                cfo.check();
+                last = f;
+            }
         }
     }
 }

--- a/CommonChickenRuntimeEngine/tests/ccre/channel/FloatOperationTest.java
+++ b/CommonChickenRuntimeEngine/tests/ccre/channel/FloatOperationTest.java
@@ -93,7 +93,7 @@ public class FloatOperationTest {
             for (float a : Values.interestingFloats) {
                 float lastExpected = cfo.valueExpected;
                 cfo.valueExpected = FloatOperation.subtraction.of(a, b);
-                cfo.ifExpected = lastExpected != cfo.valueExpected;
+                cfo.ifExpected = Float.floatToIntBits(lastExpected) != Float.floatToIntBits(cfo.valueExpected);
                 sa.set(a);
                 cfo.check();
                 assertEquals(cfo.valueExpected, fi.get(), 0);
@@ -118,7 +118,7 @@ public class FloatOperationTest {
             for (float b : Values.interestingFloats) {
                 float lastExpected = cfo.valueExpected;
                 cfo.valueExpected = FloatOperation.subtraction.of(a, b);
-                cfo.ifExpected = (lastExpected != cfo.valueExpected);
+                cfo.ifExpected = Float.floatToIntBits(lastExpected) != Float.floatToIntBits(cfo.valueExpected);
                 sb.set(b);
                 cfo.check();
                 assertEquals(cfo.valueExpected, fi.get(), 0);
@@ -142,13 +142,13 @@ public class FloatOperationTest {
         for (float a : Values.interestingFloats) {
             float lastExpected = cfo.valueExpected;
             cfo.valueExpected = FloatOperation.subtraction.of(a, sb.get());
-            cfo.ifExpected = (lastExpected != cfo.valueExpected);
+            cfo.ifExpected = Float.floatToIntBits(lastExpected) != Float.floatToIntBits(cfo.valueExpected);
             sa.set(a);
             cfo.check();
             for (float b : Values.interestingFloats) {
                 lastExpected = cfo.valueExpected;
                 cfo.valueExpected = FloatOperation.subtraction.of(a, b);
-                cfo.ifExpected = (lastExpected != cfo.valueExpected);
+                cfo.ifExpected = Float.floatToIntBits(lastExpected) != Float.floatToIntBits(cfo.valueExpected);
                 sb.set(b);
                 cfo.check();
                 assertEquals(cfo.valueExpected, fi.get(), 0);

--- a/CommonChickenRuntimeEngine/tests/ccre/cluck/CluckPublisherTest.java
+++ b/CommonChickenRuntimeEngine/tests/ccre/cluck/CluckPublisherTest.java
@@ -32,6 +32,7 @@ import ccre.channel.FloatCell;
 import ccre.channel.FloatInput;
 import ccre.channel.FloatOutput;
 import ccre.log.LogLevel;
+import ccre.log.Logger;
 import ccre.log.LoggingTarget;
 import ccre.log.VerifyingLoggingTarget;
 import ccre.testing.CountingBooleanOutput;
@@ -217,7 +218,10 @@ public class CluckPublisherTest {
             CountingBooleanOutput cbo = new CountingBooleanOutput();
             BooleanCell bs = new BooleanCell();
             CluckPublisher.publish(node, name, bs.asInput());
+            cbo.ifExpected = true;
+            cbo.valueExpected = false;
             CluckPublisher.subscribeBI(node, name, false).send(cbo);
+            cbo.check();
             for (boolean b : Values.interestingBooleans) {
                 cbo.valueExpected = b;
                 cbo.ifExpected = b != bs.get();
@@ -309,16 +313,39 @@ public class CluckPublisherTest {
 
     @Test
     public void testFloatInput() {
-        for (int i = 0; i < 20; i++) {
+        for (float starting : Values.interestingFloats) {
             String name = Values.getRandomString();
-            if (name.contains("/") || node.hasLink(name)) {
-                i--;
-                continue;
+            while (name.contains("/") || node.hasLink(name)) {
+                name = Values.getRandomString();
             }
             CountingFloatOutput cfo = new CountingFloatOutput();
-            FloatCell fs = new FloatCell();
+            FloatCell fs = new FloatCell(starting);
             CluckPublisher.publish(node, name, fs.asInput());
-            CluckPublisher.subscribeFI(node, name, false).send(cfo);
+            cfo.ifExpected = true;
+            cfo.valueExpected = 0.0f;
+            CluckPublisher.subscribeFI(node, name, false).send(new FloatOutput() {
+                private boolean first = true;
+
+                @Override
+                public void set(float v) {
+                    Logger.fine("Got: " + v);
+                    cfo.set(v);
+                    if (first) {
+                        first = false;
+                        cfo.check();
+                        // this is because the subscription will first send a
+                        // NaN and then update itself very quickly when the
+                        // response returns (which is almost immediately)
+                        cfo.ifExpected = Float.floatToIntBits(starting) != Float.floatToIntBits(0);
+                        cfo.valueExpected = starting;
+                    }
+                }
+            });
+            cfo.check();
+            cfo.valueExpected = 0;
+            cfo.ifExpected = Float.floatToIntBits(starting) != Float.floatToIntBits(0);
+            fs.set(0);
+            cfo.check();
             for (float f : Values.interestingFloats) {
                 cfo.valueExpected = f;
                 cfo.ifExpected = true;

--- a/CommonChickenRuntimeEngine/tests/ccre/testing/CountingBooleanOutput.java
+++ b/CommonChickenRuntimeEngine/tests/ccre/testing/CountingBooleanOutput.java
@@ -47,11 +47,15 @@ public class CountingBooleanOutput implements BooleanOutput {
      */
     public boolean ifExpected;
 
+    private boolean anyUnexpected;
+
     public synchronized void set(boolean value) {
         if (!ifExpected) {
+            anyUnexpected = true;
             throw new RuntimeException("Unexpected set!");
         }
         if (value != valueExpected) {
+            anyUnexpected = true;
             throw new RuntimeException("Incorrect set!");
         }
         ifExpected = false;
@@ -64,7 +68,11 @@ public class CountingBooleanOutput implements BooleanOutput {
      * @throws RuntimeException if a write did not occur.
      */
     public void check() throws RuntimeException {
+        if (anyUnexpected) {
+            throw new RuntimeException("Already failed earlier!");
+        }
         if (ifExpected) {
+            anyUnexpected = true;
             throw new RuntimeException("Did not get expected set!");
         }
     }

--- a/CommonChickenRuntimeEngine/tests/ccre/testing/CountingEventOutput.java
+++ b/CommonChickenRuntimeEngine/tests/ccre/testing/CountingEventOutput.java
@@ -59,11 +59,12 @@ public class CountingEventOutput implements EventOutput {
      * @throws RuntimeException if an event did not occur.
      */
     public synchronized void check() throws RuntimeException {
-        if (ifExpected) {
-            throw new RuntimeException("Event did not occur");
-        }
         if (anyUnexpected) {
-            throw new RuntimeException("Unexpected event");
+            throw new RuntimeException("Already failed earlier!");
+        }
+        if (ifExpected) {
+            anyUnexpected = true;
+            throw new RuntimeException("Event did not occur");
         }
     }
 }

--- a/CommonChickenRuntimeEngine/tests/ccre/util/Values.java
+++ b/CommonChickenRuntimeEngine/tests/ccre/util/Values.java
@@ -120,13 +120,23 @@ public class Values {
     }
 
     /**
+     * Generates a random float. May include numbers like NaN, infinity,
+     * MAX_VALUE, or 0.
+     *
+     * @return the random float.
+     */
+    public static float getRandomFloat() {
+        return (float) (interestingFloats[random.nextInt(interestingFloats.length)] * random.nextGaussian() * 1.5f);
+    }
+
+    /**
      * A sequence of interesting floats for testing edge cases: things like
      * negative infinity, NaN, MAX_VALUE, -MAX_VALUE, 0, 1, -1, etc.
      *
      * @see Values#lessInterestingFloats
      * @see Values#interestingBooleans
      */
-    public static final float[] interestingFloats = new float[] { Float.NEGATIVE_INFINITY, -Float.MAX_VALUE, -1024.7f, -32f, -6.3f, -1.1f, -1f, -0.7f, -0.5f, -0.3f, -0.1f, -0.001f, -Float.MIN_VALUE, 0, Float.NaN, Float.MIN_VALUE, 0.001f, 0.1f, 0.3f, 0.5f, 0.7f, 1.0f, 1.1f, 6.3f, 32f, 1024.7f, Float.MAX_VALUE, Float.POSITIVE_INFINITY };
+    public static final float[] interestingFloats = new float[] { Float.NEGATIVE_INFINITY, -Float.MAX_VALUE, -1024.7f, -32f, -6.3f, -1.1f, -1f, -0.7f, -0.5f, -0.3f, -0.1f, -0.001f, -Float.MIN_VALUE, -0.0f, +0.0f, Float.NaN, Float.MIN_VALUE, 0.001f, 0.1f, 0.3f, 0.5f, 0.7f, 1.0f, 1.1f, 6.3f, 32f, 1024.7f, Float.MAX_VALUE, Float.POSITIVE_INFINITY };
     /**
      * A sequence of slightly less interesting floats for testing edge cases:
      * this is like {@link #interestingFloats}, but with only finite values not


### PR DESCRIPTION
Review this PR after #132 has been merged.

This fixes a few mistakes in the test harnesses:

* In some cases, errors would be swallowed due to the architecture of the `Counting*Output`s. They now track every failure and will re-fail later in all cases.
* `CountingFloatOutput`s did not check bitwise equality between floats, which meant that, for example, if 0.0 was expected but -0.0 was given, the test would pass. This may seem like a counterintuitive change, but it's there to make sure that everything in the system is as precise as possible: you DO want a 0.0 -> -0.0 change to be propagated across a dataflow network!

This uncovered some actual bugs in the tests, which have now been fixed.

This PR is followed by #135.