### PR TITLE
Add PWM support for unsupported controllers

### DIFF
--- a/CommonChickenRuntimeEngine/src/ccre/frc/FRC.java
+++ b/CommonChickenRuntimeEngine/src/ccre/frc/FRC.java
@@ -286,8 +286,8 @@ public class FRC {
     }
 
     /**
-     * Create a reference to a Talon speed controller on the specified PWM port
-     * and motor reversal, with a specified ramping rate.
+     * Create a reference to a Talon SR speed controller on the specified PWM
+     * port and motor reversal, with a specified ramping rate.
      *
      * If the ramping rate is zero, then no ramping is applied. Don't use this
      * if you don't know what you're doing! Otherwise, the ramping rate is the
@@ -311,8 +311,8 @@ public class FRC {
     }
 
     /**
-     * Create a reference to a Talon speed controller on the specified PWM port
-     * and motor reversal, with a default ramping rate of 0.1, aka 200
+     * Create a reference to a Talon SR speed controller on the specified PWM
+     * port and motor reversal, with a default ramping rate of 0.1, aka 200
      * milliseconds to ramp from stopped to full speed.
      *
      * @param id the motor port ID, from 1 to 10, inclusive.
@@ -327,15 +327,227 @@ public class FRC {
     }
 
     /**
-     * Create a reference to a Talon speed controller on the specified PWM port,
-     * with a default ramping rate of 0.1, aka 200 milliseconds to ramp from
-     * stopped to full speed.
+     * Create a reference to a Talon SR speed controller on the specified PWM
+     * port, with a default ramping rate of 0.1, aka 200 milliseconds to ramp
+     * from stopped to full speed.
      *
      * @param id the motor port ID, from 1 to 10, inclusive.
      * @return the output that will output to the specified motor.
      */
     public static FloatOutput talon(int id) {
         return talon(id, false, 0.1f);
+    }
+
+    /**
+     * Create a reference to a Talon SRX speed controller on the specified PWM
+     * port and motor reversal, with a specified ramping rate.
+     *
+     * If the ramping rate is zero, then no ramping is applied. Don't use this
+     * if you don't know what you're doing! Otherwise, the ramping rate is the
+     * maximum difference allowed per 10 milliseconds (constantPeriodic). (So a
+     * rate of 0.1f means that you need 200 milliseconds to go from -1.0 to
+     * 1.0.)
+     *
+     * @param id the motor port ID, from 1 to 10, inclusive.
+     * @param negate MOTOR_FORWARD if the motor direction should be unmodified,
+     * MOTOR_REVERSE if the motor direction should be reversed.
+     * @param ramping the ramping rate.
+     * @return the output that will output to the specified motor.
+     * @see #MOTOR_FORWARD
+     * @see #MOTOR_REVERSE
+     */
+    public static FloatOutput talonSRX(int id, boolean negate, float ramping) {
+        FloatOutput motor = impl.makeMotor(id, FRCImplementation.TALONSRX);
+        FloatOutput ramped = (negate ? motor.negate() : motor).addRamping(ramping, constantPeriodic);
+        ramped.setWhen(0.0f, startDisabled);
+        return ramped;
+    }
+
+    /**
+     * Create a reference to a Talon SRX speed controller on the specified PWM
+     * port and motor reversal, with a default ramping rate of 0.1, aka 200
+     * milliseconds to ramp from stopped to full speed.
+     *
+     * @param id the motor port ID, from 1 to 10, inclusive.
+     * @param negate MOTOR_FORWARD if the motor direction should be unmodified,
+     * MOTOR_REVERSE if the motor direction should be reversed.
+     * @return the output that will output to the specified motor.
+     * @see #MOTOR_FORWARD
+     * @see #MOTOR_REVERSE
+     */
+    public static FloatOutput talonSRX(int id, boolean negate) {
+        return talonSRX(id, negate, 0.1f);
+    }
+
+    /**
+     * Create a reference to a Talon SRX speed controller on the specified PWM
+     * port, with a default ramping rate of 0.1, aka 200 milliseconds to ramp
+     * from stopped to full speed.
+     *
+     * @param id the motor port ID, from 1 to 10, inclusive.
+     * @return the output that will output to the specified motor.
+     */
+    public static FloatOutput talonSRX(int id) {
+        return talonSRX(id, false, 0.1f);
+    }
+
+    /**
+     * Create a reference to a Victor SP speed controller on the specified PWM
+     * port and motor reversal, with a specified ramping rate.
+     *
+     * If the ramping rate is zero, then no ramping is applied. Don't use this
+     * if you don't know what you're doing! Otherwise, the ramping rate is the
+     * maximum difference allowed per 10 milliseconds (constantPeriodic). (So a
+     * rate of 0.1f means that you need 200 milliseconds to go from -1.0 to
+     * 1.0.)
+     *
+     * @param id the motor port ID, from 1 to 10, inclusive.
+     * @param negate MOTOR_FORWARD if the motor direction should be unmodified,
+     * MOTOR_REVERSE if the motor direction should be reversed.
+     * @param ramping the ramping rate.
+     * @return the output that will output to the specified motor.
+     * @see #MOTOR_FORWARD
+     * @see #MOTOR_REVERSE
+     */
+    public static FloatOutput victorSP(int id, boolean negate, float ramping) {
+        FloatOutput motor = impl.makeMotor(id, FRCImplementation.VICTORSP);
+        FloatOutput ramped = (negate ? motor.negate() : motor).addRamping(ramping, constantPeriodic);
+        ramped.setWhen(0.0f, startDisabled);
+        return ramped;
+    }
+
+    /**
+     * Create a reference to a Victor SP speed controller on the specified PWM
+     * port and motor reversal, with a default ramping rate of 0.1, aka 200
+     * milliseconds to ramp from stopped to full speed.
+     *
+     * @param id the motor port ID, from 1 to 10, inclusive.
+     * @param negate MOTOR_FORWARD if the motor direction should be unmodified,
+     * MOTOR_REVERSE if the motor direction should be reversed.
+     * @return the output that will output to the specified motor.
+     * @see #MOTOR_FORWARD
+     * @see #MOTOR_REVERSE
+     */
+    public static FloatOutput victorSP(int id, boolean negate) {
+        return victorSP(id, negate, 0.1f);
+    }
+
+    /**
+     * Create a reference to a Victor SP speed controller on the specified PWM
+     * port, with a default ramping rate of 0.1, aka 200 milliseconds to ramp
+     * from stopped to full speed.
+     *
+     * @param id the motor port ID, from 1 to 10, inclusive.
+     * @return the output that will output to the specified motor.
+     */
+    public static FloatOutput victorSP(int id) {
+        return victorSP(id, false, 0.1f);
+    }
+
+    /**
+     * Create a reference to a Spark speed controller on the specified PWM port
+     * and motor reversal, with a specified ramping rate.
+     *
+     * If the ramping rate is zero, then no ramping is applied. Don't use this
+     * if you don't know what you're doing! Otherwise, the ramping rate is the
+     * maximum difference allowed per 10 milliseconds (constantPeriodic). (So a
+     * rate of 0.1f means that you need 200 milliseconds to go from -1.0 to
+     * 1.0.)
+     *
+     * @param id the motor port ID, from 1 to 10, inclusive.
+     * @param negate MOTOR_FORWARD if the motor direction should be unmodified,
+     * MOTOR_REVERSE if the motor direction should be reversed.
+     * @param ramping the ramping rate.
+     * @return the output that will output to the specified motor.
+     * @see #MOTOR_FORWARD
+     * @see #MOTOR_REVERSE
+     */
+    public static FloatOutput spark(int id, boolean negate, float ramping) {
+        FloatOutput motor = impl.makeMotor(id, FRCImplementation.SPARK);
+        FloatOutput ramped = (negate ? motor.negate() : motor).addRamping(ramping, constantPeriodic);
+        ramped.setWhen(0.0f, startDisabled);
+        return ramped;
+    }
+
+    /**
+     * Create a reference to a Spark speed controller on the specified PWM port
+     * and motor reversal, with a default ramping rate of 0.1, aka 200
+     * milliseconds to ramp from stopped to full speed.
+     *
+     * @param id the motor port ID, from 1 to 10, inclusive.
+     * @param negate MOTOR_FORWARD if the motor direction should be unmodified,
+     * MOTOR_REVERSE if the motor direction should be reversed.
+     * @return the output that will output to the specified motor.
+     * @see #MOTOR_FORWARD
+     * @see #MOTOR_REVERSE
+     */
+    public static FloatOutput spark(int id, boolean negate) {
+        return spark(id, negate, 0.1f);
+    }
+
+    /**
+     * Create a reference to a Spark speed controller on the specified PWM port,
+     * with a default ramping rate of 0.1, aka 200 milliseconds to ramp from
+     * stopped to full speed.
+     *
+     * @param id the motor port ID, from 1 to 10, inclusive.
+     * @return the output that will output to the specified motor.
+     */
+    public static FloatOutput spark(int id) {
+        return spark(id, false, 0.1f);
+    }
+
+    /**
+     * Create a reference to a SD540 speed controller on the specified PWM port
+     * and motor reversal, with a specified ramping rate.
+     *
+     * If the ramping rate is zero, then no ramping is applied. Don't use this
+     * if you don't know what you're doing! Otherwise, the ramping rate is the
+     * maximum difference allowed per 10 milliseconds (constantPeriodic). (So a
+     * rate of 0.1f means that you need 200 milliseconds to go from -1.0 to
+     * 1.0.)
+     *
+     * @param id the motor port ID, from 1 to 10, inclusive.
+     * @param negate MOTOR_FORWARD if the motor direction should be unmodified,
+     * MOTOR_REVERSE if the motor direction should be reversed.
+     * @param ramping the ramping rate.
+     * @return the output that will output to the specified motor.
+     * @see #MOTOR_FORWARD
+     * @see #MOTOR_REVERSE
+     */
+    public static FloatOutput sd540(int id, boolean negate, float ramping) {
+        FloatOutput motor = impl.makeMotor(id, FRCImplementation.SD540);
+        FloatOutput ramped = (negate ? motor.negate() : motor).addRamping(ramping, constantPeriodic);
+        ramped.setWhen(0.0f, startDisabled);
+        return ramped;
+    }
+
+    /**
+     * Create a reference to a SD540 speed controller on the specified PWM port
+     * and motor reversal, with a default ramping rate of 0.1, aka 200
+     * milliseconds to ramp from stopped to full speed.
+     *
+     * @param id the motor port ID, from 1 to 10, inclusive.
+     * @param negate MOTOR_FORWARD if the motor direction should be unmodified,
+     * MOTOR_REVERSE if the motor direction should be reversed.
+     * @return the output that will output to the specified motor.
+     * @see #MOTOR_FORWARD
+     * @see #MOTOR_REVERSE
+     */
+    public static FloatOutput sd540(int id, boolean negate) {
+        return sd540(id, negate, 0.1f);
+    }
+
+    /**
+     * Create a reference to a SD540 speed controller on the specified PWM port,
+     * with a default ramping rate of 0.1, aka 200 milliseconds to ramp from
+     * stopped to full speed.
+     *
+     * @param id the motor port ID, from 1 to 10, inclusive.
+     * @return the output that will output to the specified motor.
+     */
+    public static FloatOutput sd540(int id) {
+        return sd540(id, false, 0.1f);
     }
 
     /**

--- a/CommonChickenRuntimeEngine/src/ccre/frc/FRCImplementation.java
+++ b/CommonChickenRuntimeEngine/src/ccre/frc/FRCImplementation.java
@@ -44,13 +44,29 @@ public interface FRCImplementation {
      */
     public static final int JAGUAR = 1;
     /**
-     * The ID for a Talon speed controller.
+     * The ID for a Talon SR speed controller.
      */
     public static final int TALON = 2;
     /**
      * The ID for a Victor speed controller.
      */
     public static final int VICTOR = 3;
+    /**
+     * The ID for a Victor SP speed controller.
+     */
+    public static final int VICTORSP = 4;
+    /**
+     * The ID for a Spark speed controller.
+     */
+    public static final int SPARK = 5;
+    /**
+     * The ID for a SD540 speed controller.
+     */
+    public static final int SD540 = 6;
+    /**
+     * The ID for a Talon SRX speed controller.
+     */
+    public static final int TALONSRX = 7;
 
     /**
      * Accesses a Joystick from the Driver Station.

--- a/Emulator/src/ccre/frc/DeviceBasedImplementation.java
+++ b/Emulator/src/ccre/frc/DeviceBasedImplementation.java
@@ -132,10 +132,22 @@ public class DeviceBasedImplementation implements FRCImplementation {
                 typename = "Jaguar";
                 break;
             case FRCImplementation.TALON:
-                typename = "Talon";
+                typename = "Talon SR";
                 break;
             case FRCImplementation.VICTOR:
                 typename = "Victor";
+                break;
+            case FRCImplementation.VICTORSP:
+                typename = "Victor SP";
+                break;
+            case FRCImplementation.SPARK:
+                typename = "Spark";
+                break;
+            case FRCImplementation.SD540:
+                typename = "SD540";
+                break;
+            case FRCImplementation.TALONSRX:
+                typename = "Talon SRX (PWM)";
                 break;
             default:
                 typename = "Unknown (%" + type + ")";

--- a/roboRIO/src/ccre/frc/DirectFRCImplementation.java
+++ b/roboRIO/src/ccre/frc/DirectFRCImplementation.java
@@ -470,6 +470,18 @@ public final class DirectFRCImplementation implements FRCImplementation {
         case TALON:
             DirectPWM.init(id, DirectPWM.TYPE_TALON);
             break;
+        case VICTORSP:
+            DirectPWM.init(id, DirectPWM.TYPE_VICTORSP);
+            break;
+        case SPARK:
+            DirectPWM.init(id, DirectPWM.TYPE_SPARK);
+            break;
+        case SD540:
+            DirectPWM.init(id, DirectPWM.TYPE_SD540);
+            break;
+        case TALONSRX:
+            DirectPWM.init(id, DirectPWM.TYPE_TALONSRX);
+            break;
         default:
             throw new IllegalArgumentException("Unknown motor type: " + type);
         }

--- a/roboRIO/src/ccre/frc/DirectPWM.java
+++ b/roboRIO/src/ccre/frc/DirectPWM.java
@@ -33,7 +33,11 @@ class DirectPWM {
     public static final int TYPE_JAGUAR = 1;
     public static final int TYPE_VICTOR = 2;
     public static final int TYPE_SERVO = 3;
-    public static final int TYPE_NUM = 4;
+    public static final int TYPE_VICTORSP = 4;
+    public static final int TYPE_SPARK = 5;
+    public static final int TYPE_SD540 = 6;
+    public static final int TYPE_TALONSRX = 7;
+    public static final int TYPE_NUM = 8;
     private static final long[] pwms = new long[PWM_NUM];
     private static final int[] types = new int[PWM_NUM];
     private static final int[] tmax = new int[TYPE_NUM],
@@ -43,11 +47,12 @@ class DirectPWM {
     private static final int kSystemClockTicksPerMicrosecond = 40;
     private static final double kDefaultPwmCenter = 1.5;
     private static final int kDefaultPwmStepsDown = 1000;
-    private static final double[] cmax = new double[] { 2.037, 2.31, 2.027, 2.6 },
-            cdbMax = new double[] { 1.539, 1.55, 1.525, 0 },
-            cctr = new double[] { 1.513, 1.507, 1.507, 0 },
-            cdbMin = new double[] { 1.487, 1.454, 1.49, 0 },
-            cmin = new double[] { 0.989, 0.697, 1.026, 0.6 };
+    private static final double[] cmax = new double[] { 2.037, 2.31, 2.027, 2.6, 2.004, 2.003, 2.05, 2.004 },
+            cdbMax = new double[] { 1.539, 1.55, 1.525, 0, 1.52, 1.55, 1.55, 1.52 },
+            cctr = new double[] { 1.513, 1.507, 1.507, 0, 1.50, 1.50, 1.50, 1.50 },
+            cdbMin = new double[] { 1.487, 1.454, 1.49, 0, 1.48, 1.46, 1.44, 1.48 },
+            cmin = new double[] { 0.989, 0.697, 1.026, 0.6, 0.997, 0.999, 0.94, 0.997 };
+    private static final int[] scaling = new int[] { 1, 1, 2, 4, 1, 1, 1, 1 };
 
     private static synchronized void initConfig() {
         double loopTime = DIOJNI.getLoopTiming() / (kSystemClockTicksPerMicrosecond * 1e3);
@@ -83,7 +88,7 @@ class DirectPWM {
                 initConfig();
             }
 
-            configureScaling(port, type == TYPE_SERVO ? 4 : type == TYPE_VICTOR ? 2 : 1);
+            configureScaling(port, scaling[type]);
 
             if (type != TYPE_SERVO) {
                 PWMJNI.latchPWMZero(port);


### PR DESCRIPTION
Add support for Talon SRX (over PWM), Spark, SD540, and Jaguar SP.

I really should have remembered this earlier.